### PR TITLE
Add "Organize with Groups" message to groups page

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -188,7 +188,8 @@
       "description": "Description"
     },
     "headers": {
-      "discoverGroups": "Discover Groups"
+      "discoverGroups": "Discover Groups",
+      "organizeWithGroups": "Organize Your Community with Groups"
     },
     "errors": {
       "couldNotCreate": "Group could not be created",
@@ -211,6 +212,9 @@
     },
     "prompts": {
       "confirmLeave": "Are you sure you want to leave the group?"
+    },
+    "tips": {
+      "organizeWithGroups": "Groups are a great way to organize your community and connect with like-minded people. Whether you want to share your interests, plan events, or collaborate on projects, groups are the perfect place to do it. Start a group today and see how it can help you organize your community."
     }
   },
 

--- a/src/pages/groups/index.tsx
+++ b/src/pages/groups/index.tsx
@@ -1,19 +1,65 @@
 import { useReactiveVar } from "@apollo/client";
-import { Typography } from "@mui/material";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Typography,
+  useTheme,
+} from "@mui/material";
 import { NextPage } from "next";
 import { useTranslation } from "react-i18next";
-import { isLoggedInVar } from "../../apollo/cache";
+import { inviteTokenVar, isLoggedInVar } from "../../apollo/cache";
 import { useGroupsQuery } from "../../apollo/gen";
 import GroupCard from "../../components/Groups/GroupCard";
 import GroupForm from "../../components/Groups/GroupForm";
 import LevelOneHeading from "../../components/Shared/LevelOneHeading";
+import Link from "../../components/Shared/Link";
 import ProgressBar from "../../components/Shared/ProgressBar";
+import { NavigationPaths } from "../../constants/common.constants";
 import { isDeniedAccess } from "../../utils/error.utils";
 
 const GroupsIndex: NextPage = () => {
-  const { data, loading, error } = useGroupsQuery();
   const isLoggedIn = useReactiveVar(isLoggedInVar);
+  const inviteToken = useReactiveVar(inviteTokenVar);
+  const { data, loading, error } = useGroupsQuery();
+
   const { t } = useTranslation();
+  const theme = useTheme();
+
+  if (!isLoggedIn) {
+    return (
+      <Card>
+        <CardHeader
+          title={t("groups.headers.organizeWithGroups")}
+          sx={{ color: theme.palette.primary.main, paddingBottom: 0.75 }}
+        />
+
+        <CardContent>
+          <Typography gutterBottom>
+            {t("groups.tips.organizeWithGroups")}
+          </Typography>
+
+          <Typography>
+            {inviteToken && (
+              <>
+                <Link
+                  href={`/signup/${inviteToken}`}
+                  sx={{ marginRight: "0.5ch" }}
+                >
+                  {t("users.actions.signUp")}
+                </Link>
+                or
+              </>
+            )}
+            <Link href={NavigationPaths.LogIn} sx={{ marginLeft: "0.5ch" }}>
+              {t("users.actions.logIn")}
+            </Link>{" "}
+            to explore groups
+          </Typography>
+        </CardContent>
+      </Card>
+    );
+  }
 
   if (isDeniedAccess(error)) {
     return <Typography>{t("prompts.permissionDenied")}</Typography>;


### PR DESCRIPTION
Adds a message to the groups page when the user is logged out, which explains how groups can be used to organize communities:
> Groups are a great way to organize your community and connect with like-minded people. Whether you want to share your interests, plan events, or collaborate on projects, groups are the perfect place to do it. Start a group today and see how it can help you organize your community.